### PR TITLE
add better schedule filtering

### DIFF
--- a/src/pages/schedule/schedule.html
+++ b/src/pages/schedule/schedule.html
@@ -27,14 +27,14 @@
 
 <ion-content>
   <session-list
-    *ngIf="(groups$ | async)?.length > 0"
+    *ngIf="!emptyState"
     [groups]="groups$ | async"
     [options]="segment === 'all'"
     (toggle)="toggleFavorite($event)"
     (select)="goToSessionDetail($event)">
   </session-list>
 
-  <ion-list-header *ngIf="(groups$ | async)?.length === 0">
+  <ion-list-header *ngIf="emptyState">
       No Sessions Found
   </ion-list-header>
 

--- a/src/shared/entities/session-group.ts
+++ b/src/shared/entities/session-group.ts
@@ -4,4 +4,5 @@ export interface SessionGroup {
   sessions: Session[];
   startHour: number;
   endHour: number;
+  hidden?: boolean;
 }

--- a/src/shared/services/conference-data.service.ts
+++ b/src/shared/services/conference-data.service.ts
@@ -34,7 +34,6 @@ export class ConferenceDataService {
           session.speakers = [];
 
           delete session.roomId;
-          this.favoritesService.checkFavorite(session);
 
           return session;
         });


### PR DESCRIPTION
I believe this should impact performance quite a lot in the good way. Especially on mobile, the app is quite laggy when switching tabs and filtering the list. I'm now also using a `favorites$` observable stream which I believe we can easily replace with a firebase version in the future.

But, because of this, I introduced this error in the `console`. I know that it is coming because of this piece of code in `favorites.service.ts`

```js
    this.storage.get('favorites')
      .then(JSON.parse)
      .then(favorites => {
        this.favorites$.next(favorites || []);
      });
```

I'm just not sure WHY. If I'm not mistaken, the `ng-be` app suffers from the same error.

<img width="356" alt="screen shot 2017-02-08 at 00 18 46" src="https://cloud.githubusercontent.com/assets/1913805/22716096/6ea7f728-ed94-11e6-8409-a717bd7769cf.png">
