### PR TITLE
fix(error): Fixes the uncaught exception error

### DIFF
--- a/src/pages/schedule/schedule.ts
+++ b/src/pages/schedule/schedule.ts
@@ -69,7 +69,9 @@ export class SchedulePage implements OnInit, OnDestroy {
 
   updateSchedule() {
     // Close any open sliding items when the schedule updates
-    this.scheduleList && this.scheduleList.closeSlidingItems();
+    if (this.scheduleList) {
+      this.scheduleList.closeSlidingItems();
+    }
 
     this.groups$ = this.search$.switchMap(term => {
       term = typeof term === 'string' ? term.toLowerCase() : '';
@@ -106,7 +108,7 @@ export class SchedulePage implements OnInit, OnDestroy {
         });
     });
 
-    this.groups$.subscribe(() => {
+    this.groups$.take(1).subscribe(() => {
       this.closeLoader();
     });
   }
@@ -183,6 +185,7 @@ export class SchedulePage implements OnInit, OnDestroy {
   private closeLoader() {
     if (this.loader) {
       this.loader.dismissAll();
+      this.loader = null;
     }
   }
 

--- a/src/shared/services/favorites.service.ts
+++ b/src/shared/services/favorites.service.ts
@@ -11,11 +11,15 @@ export class FavoritesService {
   favorites$ = new ReplaySubject<string[]>();
 
   constructor(private storage: Storage) {
-    this.storage.get('favorites')
-      .then(JSON.parse)
-      .then(favorites => {
-        this.favorites$.next(favorites || []);
-      });
+    try {
+      this.storage.get('favorites')
+        .then(JSON.parse)
+        .then(favorites => {
+          this.favorites$.next(favorites || []);
+        });
+    } catch (err) {
+      this.favorites$.next([]);
+    }
   }
 
   toggleFavorite(session: Session): Promise<boolean> {


### PR DESCRIPTION
:tada:

The thing was that `closeLoader()` was called multiple times even though the loader was already dismissed. By setting the loader to `null`, this issue is solved.
