### PR TITLE
fix(timezone): Date formatting in the correct timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",
     "lodash": "^4.17.4",
+    "moment-timezone": "^0.5.11",
     "rxjs": "5.1.0",
     "sw-toolbox": "3.4.0",
     "zone.js": "0.6.26"

--- a/src/pages/schedule/session-item/session-item.component.html
+++ b/src/pages/schedule/session-item/session-item.component.html
@@ -2,8 +2,8 @@
   <ion-item (click)="select.next()">
     <h3>{{session.title}}</h3>
     <p>
-      {{session.startDate | date:'HH:mm'}} &mdash;
-      {{session.endDate | date:'HH:mm'}}:
+      {{session.startDate | tzDate:'HH:mm'}} &mdash;
+      {{session.endDate | tzDate:'HH:mm'}}:
       {{session.room}}
     </p>
     <ion-icon name="bookmark" item-right *ngIf="!session.favorited && options"></ion-icon>

--- a/src/pages/session-detail/session-info/session-info.component.html
+++ b/src/pages/session-detail/session-info/session-info.component.html
@@ -1,7 +1,7 @@
 <table>
   <tr>
     <th>Slot:</th>
-    <td>{{session.startDate | date:'HH:mm'}} - {{session.endDate | date:'HH:mm'}}</td>
+    <td>{{session.startDate | tzDate:'HH:mm'}} - {{session.endDate | tzDate:'HH:mm'}}</td>
   </tr>
   <tr>
     <th>Room:</th>

--- a/src/shared/pipes/index.ts
+++ b/src/shared/pipes/index.ts
@@ -1,0 +1,1 @@
+export { TimezoneDatePipe } from './timezone-date.pipe';

--- a/src/shared/pipes/timezone-date.pipe.ts
+++ b/src/shared/pipes/timezone-date.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import moment from 'moment-timezone';
+
+@Pipe({
+  name: 'tzDate'
+})
+export class TimezoneDatePipe implements PipeTransform {
+  transform(value: any, ...args: any[]): any {
+    return moment(value).tz(args[1] || 'Europe/Copenhagen').format(args[0]);
+  }
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,12 +1,11 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 
 import { ConferenceDataService, URLService, ConnectionService, FavoritesService } from './services';
+import { TimezoneDatePipe } from './pipes/timezone-date.pipe';
 
 @NgModule({
-  imports: [],
-  exports: [],
-  declarations: [],
-  providers: []
+  declarations: [TimezoneDatePipe],
+  exports: [TimezoneDatePipe]
 })
 export class SharedModule {
   static forRoot(): ModuleWithProviders {


### PR DESCRIPTION
Added a `tzDate` pipe with a default timezone of `Europe/Copenhagen`.