### PR TITLE
use proper pages and titles for analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-browser-dynamic": "2.2.1",
     "@angular/platform-server": "2.2.1",
     "@ionic/storage": "1.1.7",
-    "angular-ga": "^0.1.3",
+    "angular-ga": "^0.2.0",
     "angularfire2": "^2.0.0-beta.7",
     "firebase": "^3.6.8",
     "ionic-angular": "2.0.0",

--- a/src/pages/schedule/schedule.ts
+++ b/src/pages/schedule/schedule.ts
@@ -61,7 +61,7 @@ export class SchedulePage implements OnInit, OnDestroy {
 
   ionViewDidEnter() {
     this.ga.pageview.emit({
-      page: 'Schedule'
+      page: '/schedule'
     });
   }
 

--- a/src/pages/session-detail/session-detail.ts
+++ b/src/pages/session-detail/session-detail.ts
@@ -62,7 +62,8 @@ export class SessionDetailPage {
 
   ionViewDidEnter() {
     this.ga.pageview.emit({
-      page: `Session - ${this.session.title}`
+      page: `/session/${this.session.$key}`,
+      title: `Session - ${this.session.title}`
     });
   }
 

--- a/src/pages/speaker-detail/speaker-detail.ts
+++ b/src/pages/speaker-detail/speaker-detail.ts
@@ -30,7 +30,8 @@ export class SpeakerDetailPage {
 
   ionViewDidEnter() {
     this.ga.pageview.emit({
-      page: `Speaker - ${this.speaker.name}`
+      page: `/speaker/${this.speaker.$key}`,
+      title: `Speaker - ${this.speaker.name}`
     });
   }
 }

--- a/src/pages/speakers/speakers.ts
+++ b/src/pages/speakers/speakers.ts
@@ -52,7 +52,7 @@ export class SpeakersPage {
 
   ionViewDidEnter() {
     this.ga.pageview.emit({
-      page: 'Speakers'
+      page: '/speakers'
     });
   }
 

--- a/src/shared/entities/speaker.ts
+++ b/src/shared/entities/speaker.ts
@@ -1,4 +1,5 @@
 export interface Speaker {
+  $key: string;
   name: string;
   company: string;
   avatar: string;


### PR DESCRIPTION
The `page` property has to be a URL path starting with a `/` as described in the [documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages#pageview_fields). So I used the ID of the speaker and the session and also set a title.

If not title is set, the document title is automatically used which is the name of the speaker. While this is quite okay, it's cleaner in the analytics panel if we prefix it with `Speaker - ` and `Session -` to make it clearer what it is.