### PR TITLE
subscribe on the groups$ observable in schedule.ts

### DIFF
--- a/src/pages/schedule/schedule.ts
+++ b/src/pages/schedule/schedule.ts
@@ -67,6 +67,9 @@ export class SchedulePage implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.presentLoader();
+    this.confData.rpSessionGroups$.take(1).subscribe(() => {
+      this.closeLoader();
+    });
   }
 
   ngOnDestroy() {
@@ -116,9 +119,8 @@ export class SchedulePage implements OnInit, OnDestroy {
         });
     });
 
-    this.groups$.take(1).subscribe(() => {
-      this.closeLoader();
-    });
+    this.groups$.subscribe();
+  
   }
 
   goToSessionDetail(session: Session) {


### PR DESCRIPTION
My guess: Looks like the only subscriber on observable was the one that closed the loader. and since it filtered away everything except the first value, the poor observable got forgotten when groups became empty and the whole process stopped working. 
I tried to subscribe on the whole thing, and as well changed closing of the loader based on what confDataService returns. Looks like it works? :)